### PR TITLE
Increase buffer size to accommodate larger messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 /// A data readout message from the metering system as per section 6.2.
 pub struct Readout {
-    pub buffer: [u8; 1024], // Maximum size of a Readout
+    pub buffer: [u8; 2048], // Maximum size of a Readout
 }
 
 impl Readout {
@@ -93,7 +93,7 @@ extern crate std;
 mod tests {
     #[test]
     fn example() {
-        let mut buffer = [0u8; 1024];
+        let mut buffer = [0u8; 2048];
         let file = std::fs::read("test/telegram.txt").unwrap();
 
         let (left, _right) = buffer.split_at_mut(file.len());

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -26,7 +26,7 @@ impl<T: core::iter::Iterator<Item = u8>> Iterator for Reader<T> {
             }
         }
 
-        let mut buffer = [0u8; 1024];
+        let mut buffer = [0u8; 2048];
         buffer[0] = b'/';
 
         let mut i = 1;

--- a/src/state.rs
+++ b/src/state.rs
@@ -116,7 +116,7 @@ impl<'a> core::convert::From<&crate::Telegram<'a>> for crate::Result<State> {
 mod tests {
     #[test]
     fn example() {
-        let mut buffer = [0u8; 1024];
+        let mut buffer = [0u8; 2048];
         let file = std::fs::read("test/telegram.txt").unwrap();
 
         let (left, _right) = buffer.split_at_mut(file.len());


### PR DESCRIPTION
My meter spitted out messages of 1056 bytes. Increased the buffer size from 1024 to 2048.