### PR TITLE
Disable `serde/std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["no-std", "parser-implementations"]
 
 [dependencies]
 crc16 = "0.4.0"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"], default-features = false }


### PR DESCRIPTION
By default, Serde depends on libstd which makes this crate incompatible with `no_std` environments (I'm trying to use this crate on an RP2040). The simple fix, which I've implemented here, is to disable the `std` feature for Serde.